### PR TITLE
Add upsert for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ body = {
 }
 client.update_subscriber_credentials('<insert-subscriber-id>', body)
 ```
-- Upsert (append) subscriber credentials: `upsert_subscriber_credentials(subscriber_id, body)`
+- Upsert subscriber credentials: `upsert_subscriber_credentials(subscriber_id, body)`
 
 ```ruby
 body = {
@@ -675,7 +675,8 @@ body = {
     }
 }
 client.upsert_subscriber_credentials('<insert-subscriber-id>', body)
-`
+```
+
 - Delete subscriber credentials by providerId: `delete_subscriber_credentials(subscriberId, providerId)`
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -665,7 +665,17 @@ body = {
 }
 client.update_subscriber_credentials('<insert-subscriber-id>', body)
 ```
+- Upsert (append) subscriber credentials: `upsert_subscriber_credentials(subscriber_id, body)`
 
+```ruby
+body = {
+    'providerId' => '<insert-provider-id>',
+    'credentials' => {
+        # Insert all fields here
+    }
+}
+client.upsert_subscriber_credentials('<insert-subscriber-id>', body)
+`
 - Delete subscriber credentials by providerId: `delete_subscriber_credentials(subscriberId, providerId)`
 
 ```ruby

--- a/lib/novu/api/subscribers.rb
+++ b/lib/novu/api/subscribers.rb
@@ -103,6 +103,22 @@ module Novu
         put("/subscribers/#{subscriber_id}/credentials", body: body)
       end
 
+      # Upsert subscriber credentials from the Novu platform. Subscriber credentials associated to the delivery methods such as slack and push tokens.
+      #
+      # @pathparams:
+      # @param `subscriber_id` [String] The ID of the subscriber to update credentials.
+      #
+      # @bodyparams:
+      # @param `providerId` [String] The provider identifier for the credentials
+      # @param `credentials` [Hash] Credentials payload for the specified provider
+      #
+      # @return [Hash] Hash of updated subscriber credentials entity
+      # @return [number] status
+      #  - Returns 200 if the subscriber credentials has been updated correctly.
+      def upsert_subscriber_credentials(subscriber_id, body)
+        patch("/subscribers/#{subscriber_id}/credentials", body: body)
+      end
+
       # Delete subscriber credentials by providerId
       # Delete subscriber credentials such as slack and expo tokens.
       #

--- a/lib/novu/api/subscribers.rb
+++ b/lib/novu/api/subscribers.rb
@@ -87,7 +87,8 @@ module Novu
         delete("/subscribers/#{subscriber_id}")
       end
 
-      # Update subscriber credentials from the Novu platform. Subscriber credentials associated to the delivery methods such as slack and push tokens.
+      # Update subscriber credentials from the Novu platform. Subscriber credentials
+      # associated to the delivery methods such as slack and push tokens.
       #
       # @pathparams:
       # @param `subscriber_id` [String] The ID of the subscriber to update credentials.
@@ -103,7 +104,8 @@ module Novu
         put("/subscribers/#{subscriber_id}/credentials", body: body)
       end
 
-      # Upsert subscriber credentials from the Novu platform. Subscriber credentials associated to the delivery methods such as slack and push tokens.
+      # Upsert subscriber credentials from the Novu platform. Subscriber credentials
+      # associated to the delivery methods such as slack and push tokens.
       #
       # @pathparams:
       # @param `subscriber_id` [String] The ID of the subscriber to update credentials.

--- a/spec/subscribers_spec.rb
+++ b/spec/subscribers_spec.rb
@@ -159,6 +159,28 @@ RSpec.describe Novu::Api::Subscribers do
     end
   end
 
+  describe "#upsert_subscriber_credentials" do
+    it "appends the subscriber credentials" do
+      body = {
+        providerId: "slack",
+        credentials: { token: "new-slack-token" }
+      }.to_json
+
+      response_body = {
+        _id: "63f71b3ef067290fa669106d"
+      }.to_json
+
+      stub_request(:patch, "#{base_uri}/subscribers/#{subscriber_id}/credentials")
+        .with(body: body)
+        .to_return(status: 200, body: response_body)
+
+      result = client.upsert_subscriber_credentials(subscriber_id, body)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(200)
+    end
+  end
+
   describe "#delete_subscriber_credentials" do
     it "#Delete subscriber credentials such as slack and expo tokens." do
       providerId = 'slack'

--- a/spec/subscribers_spec.rb
+++ b/spec/subscribers_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Novu::Api::Subscribers do
   end
 
   describe "#upsert_subscriber_credentials" do
-    it "appends the subscriber credentials" do
+    it "upserts the subscriber credentials" do
       body = {
         providerId: "slack",
         credentials: { token: "new-slack-token" }


### PR DESCRIPTION
This adds a call to the `PATCH` endpoint for subscriber credentials to `upsert` instead of `update`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include usage instructions and an example for managing subscriber credentials with a new upsert method.

* **New Features**
  * Introduced a method for upserting (inserting or updating) subscriber credentials, enabling flexible management of delivery methods like Slack and push tokens.

* **Tests**
  * Added tests to verify correct behavior of the new upsert subscriber credentials functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->